### PR TITLE
Handles Tinymod menu crashes

### DIFF
--- a/internal/action/item.go
+++ b/internal/action/item.go
@@ -11,6 +11,7 @@ import (
 	"github.com/hectorgimenez/koolo/internal/game"
 	"github.com/hectorgimenez/koolo/internal/ui"
 	"github.com/hectorgimenez/koolo/internal/utils"
+	"github.com/lxn/win"
 )
 
 func doesExceedQuantity(rule nip.Rule) bool {
@@ -60,8 +61,12 @@ func DropInventoryItem(i data.Item) error {
 	// Check if any other menu is open, except the inventory
 	for ctx.Data.OpenMenus.IsMenuOpen() {
 
-		// Press escape to close it
-		ctx.HID.PressKey(0x1B) // ESC
+		// Press escape to close it, or spacebar in legacy mode to prevent crashes
+		if ctx.Data.LegacyGraphics {
+			ctx.HID.PressKey(win.VK_SPACE)
+		} else {
+			ctx.HID.PressKey(0x1B) // ESC
+		}
 		utils.Sleep(500)
 		closeAttempts++
 

--- a/internal/action/step/close_all_menus.go
+++ b/internal/action/step/close_all_menus.go
@@ -21,7 +21,13 @@ func CloseAllMenus() error {
 		if attempts > 10 {
 			return errors.New("failed closing game menu")
 		}
-		ctx.HID.PressKey(win.VK_ESCAPE)
+
+		// Use spacebar in legacy mode to prevent game crashes with tiny mod
+		if ctx.Data.LegacyGraphics {
+			ctx.HID.PressKey(win.VK_SPACE)
+		} else {
+			ctx.HID.PressKey(win.VK_ESCAPE)
+		}
 		utils.Sleep(200)
 		attempts++
 	}


### PR DESCRIPTION
Tiny mod menu crashes in legacy mode when esc out of exit game menu or selecting return to game. This switches to using space bar to cancel out of most menus